### PR TITLE
Add bash utilities familiarity to rewrite rust compiler integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ described here, however there is still a lot of follow-up work left to be done.
 
 Intermediate knowledge of Rust.
 
+Familiarity with standard bash utilities and their behavior preferred (e.g. `grep`, `nm` and others).
+
 **Project size**
 
 Medium or large.


### PR DESCRIPTION
From this [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/421156-gsoc/topic/Idea.3A.20rewrite.20the.20Rust.20compiler's.20integration.20tests.20in.20Rust/near/422893124)